### PR TITLE
ci: make checks cross-platform and reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,28 +22,23 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Create virtualenv & install deps
+      - name: Install dependencies
         run: |
-          python -m venv .venv
-          # Linux/macOS
-          source .venv/bin/activate
-          # Windows (PowerShell):
-          #   .venv\Scripts\Activate.ps1
-          pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install -r requirements-dev.txt
 
       - name: Check formatting (Black)
-        run: .venv/bin/black --check .
+        run: python -m black --check .
 
       - name: Check import sorting (isort)
-        run: .venv/bin/isort --check-only .
+        run: python -m isort --check-only .
 
       - name: Lint (Flake8)
-        run: .venv/bin/flake8 .
+        run: python -m flake8 .
 
       - name: Type-check (Mypy)
-        run: .venv/bin/mypy .
+        run: python -m mypy .
 
       - name: Run tests
-        run: .venv/bin/pytest -q --maxfail=1 --disable-warnings
+        run: python -m pytest -q --maxfail=1 --disable-warnings

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ alembic upgrade head
 
 ## Reproducible Verification Steps
 
-Run from the repository root with your virtual environment active:
+Run from the repository root with your virtual environment active.
+These are the same check commands used in CI:
 
 ```bash
 python -m black --check .


### PR DESCRIPTION
Use python -m tooling in CI so commands run consistently across Linux, macOS, and Windows, and align README verification steps with the exact CI command pattern.